### PR TITLE
Share spawn position visions

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -85,8 +85,11 @@ ENABLE_GRAVESTONE_ON_LEAVING_TIME_MINS = 15
 -- Enable quick start items
 ENABLE_POWER_ARMOR_QUICK_START = false
 
--- Enable shared vision between teams (all teams are still COOP)
-ENABLE_SHARED_TEAM_VISION = true
+-- Enable shared player vision between teams (all teams are still COOP)
+ENABLE_SHARED_TEAM_PLAYER_VISION = true
+
+-- Enable shared spawn position vision between teams
+ENABLE_SHARED_TEAM_SPAWN_POSITION_VISION = ENABLE_SHARED_TEAM_PLAYER_VISION and true
 
 -- Enable map regrowth, see regrowth_map.lua for more info.
 ENABLE_REGROWTH = false

--- a/control.lua
+++ b/control.lua
@@ -280,7 +280,7 @@ end)
 ----------------------------------------
 script.on_event(defines.events.on_tick, function(event)
     -- Every few seconds, chart all players to "share vision"
-    if ENABLE_SHARED_TEAM_VISION then
+    if ENABLE_SHARED_TEAM_PLAYER_VISION then
         ShareVisionBetweenPlayers()
     end
 

--- a/control.lua
+++ b/control.lua
@@ -281,7 +281,11 @@ end)
 script.on_event(defines.events.on_tick, function(event)
     -- Every few seconds, chart all players to "share vision"
     if ENABLE_SHARED_TEAM_PLAYER_VISION then
-        ShareVisionBetweenPlayers()
+        SharePlayerVisionBetweenPlayers()
+    end
+
+    if ENABLE_SHARED_TEAM_SPAWN_POSITION_VISION then
+        ShareSpawnPositionVisionBetweenPlayers()
     end
 
     if ENABLE_REGROWTH then

--- a/separate_spawns.lua
+++ b/separate_spawns.lua
@@ -291,7 +291,7 @@ end
 -- are in.
 -- I have no idea how compute intensive this function is. If it starts to lag the game
 -- we'll have to figure out how to change it.
-function ShareVisionBetweenPlayers()
+function SharePlayerVisionBetweenPlayers()
 
     if ((game.tick % (TICKS_PER_SECOND*5)) == 0) then
         
@@ -307,6 +307,33 @@ function ShareVisionBetweenPlayers()
                                      player.position.y-CHUNK_SIZE},
                                      {player.position.x+CHUNK_SIZE,
                                      player.position.y+CHUNK_SIZE}})
+                    end
+                end
+            end
+        end
+
+        global.tick_counter = 0
+    else
+        global.tick_counter = global.tick_counter + 1
+    end
+end
+
+function ShareSpawnPositionVisionBetweenPlayers()
+
+    if ((game.tick % (TICKS_PER_SECOND*5)) == 0) then
+        
+        for _,force in pairs(game.forces) do
+            if (force ~= nil) then
+                if ((force.name ~= enemy) and
+                    (force.name ~= neutral) and
+                    (force.name ~= player)) then
+
+                    for _,spawns in pairs(global.sharedSpawns) do
+                        force.chart(GAME_SURFACE_NAME,
+                                    {{spawns.position.x-CHUNK_SIZE,
+                                     spawns.position.y-CHUNK_SIZE},
+                                     {spawns.position.x+CHUNK_SIZE,
+                                     spawns.position.y+CHUNK_SIZE}})
                     end
                 end
             end


### PR DESCRIPTION
# Agenda

- Share spawn position(= the first factory) vision to all forces.

# Checklist

- Check it works

# Note

- `global.playerSpawns` looks like player's specific spawn position, and `global.sharedSpawns` looks like forces spawn position